### PR TITLE
Add Customizer overlay support

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -63,12 +63,14 @@ export async function loader({context}: LoaderFunctionArgs) {
     layout,
     isPreviewModeEnabled,
     analytics,
+    customizerMeta: pack.preview?.session.get('customizerMeta'),
   };
 }
 
 export default function App() {
   const hasUserConsent = true;
-  const {siteSettings, isPreviewModeEnabled} = useLoaderData<typeof loader>();
+  const {siteSettings, isPreviewModeEnabled, customizerMeta} =
+    useLoaderData<typeof loader>();
 
   useShopifyCookies({hasUserConsent});
   useAnalytics(hasUserConsent, DEFAULT_LOCALE);
@@ -87,6 +89,7 @@ export default function App() {
         <PreviewProvider
           isPreviewModeEnabled={isPreviewModeEnabled}
           siteSettings={siteSettings}
+          customizerMeta={customizerMeta}
         >
           <Layout>
             <Outlet />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "hello-world",
       "version": "0.0.0",
       "dependencies": {
-        "@pack/client": "^0.0.6",
-        "@pack/hydrogen": "^0.0.6",
-        "@pack/react": "^0.0.13",
+        "@pack/client": "^0.0.7",
+        "@pack/hydrogen": "^0.1.0",
+        "@pack/react": "^0.1.0",
         "@remix-run/react": "^2.4.1",
         "@shopify/cli": "^3.53.0",
         "@shopify/cli-hydrogen": "^6.1.0",
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "^2.4.1",
-        "@shopify/oxygen-workers-types": "^3.17.2",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
@@ -4061,17 +4061,17 @@
       }
     },
     "node_modules/@pack/client": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@pack/client/-/client-0.0.6.tgz",
-      "integrity": "sha512-TQO8NmNNISvCL5V5n3X3UKE9yExcz6pb8iSro75AaMU/UlznzbPXU+SjRhiVqxcdaT8P2QR1aCHrEACHlfj3ow==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pack/client/-/client-0.0.7.tgz",
+      "integrity": "sha512-NcE+H7Sf/V495MaEwk1fgeaOr/7U90on8bcvPYdN68ZhwAEwVtJzWEh6RAskQEr/fWHX4l/wRlME3Vdxlq9EUQ==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@pack/hydrogen": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@pack/hydrogen/-/hydrogen-0.0.6.tgz",
-      "integrity": "sha512-jiLveIpa8ZRbgVETyV5/JU5tP381tx7KMNRZyJb7esfP/nZki+5AR1hYcvN/B7qOCIDZy8WJogQKOBOeJA6T9Q==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@pack/hydrogen/-/hydrogen-0.1.0.tgz",
+      "integrity": "sha512-V94nlhoqmeNtU77UGXpydjFaRHoGTb6C9LGxN6TRoER5FYBSNVKfYHujOJkq/MjvZssaX1iRI6V7dme+uI44dA==",
       "dependencies": {
         "@pack/client": "^0.0.7",
         "@shopify/hydrogen": "^2023.10.2"
@@ -4083,18 +4083,10 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@pack/hydrogen/node_modules/@pack/client": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@pack/client/-/client-0.0.7.tgz",
-      "integrity": "sha512-NcE+H7Sf/V495MaEwk1fgeaOr/7U90on8bcvPYdN68ZhwAEwVtJzWEh6RAskQEr/fWHX4l/wRlME3Vdxlq9EUQ==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@pack/react": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@pack/react/-/react-0.0.13.tgz",
-      "integrity": "sha512-WvhfLvEZdr3U3V3yHZP/petI+EuCkjUrbhtUlh+yWl6LlgkuSsnLXMPhXyvwt7a2fKZO9U/0bKtOBHz4DQul+Q==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@pack/react/-/react-0.1.0.tgz",
+      "integrity": "sha512-1mX0NoPPUgjTygXOTK0AC5670aT06YYNWaXBDN/RWBAqLJRt8Yl1+tKHkFRtkwagbGCSDQOdgOhNwGpmUfmS7w==",
       "dependencies": {
         "penpal": "^6.2.2"
       },
@@ -5789,9 +5781,10 @@
       }
     },
     "node_modules/@shopify/oxygen-workers-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/@shopify/oxygen-workers-types/-/oxygen-workers-types-3.17.3.tgz",
-      "integrity": "sha512-lGeQN6V6i5rZ9kBH2hrldAOCRdWleQXLJs9wbb+iM9YngL7qbC97w253O3MDoYfFaNF4GwS9isDfLuXFl1SQbA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@shopify/oxygen-workers-types/-/oxygen-workers-types-4.0.0.tgz",
+      "integrity": "sha512-9MiXUSu0kXA9mNPMDK6+S8eRuGZ6o0HB4/P1ebZzFlsxFYxfvTu29KDJv/RYKoJufniv/WNSvwHKFyDgEmkJnw==",
+      "hasInstallScript": true
     },
     "node_modules/@shopify/plugin-did-you-mean": {
       "version": "3.53.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "scripts": {
     "build": "shopify hydrogen build",
-    "dev": "shopify hydrogen dev --worker --codegen",
+    "dev": "shopify hydrogen dev --worker --codegen --port 8080",
     "preview": "npm run build && shopify hydrogen preview --worker",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
@@ -14,8 +14,8 @@
   "prettier": "@shopify/prettier-config",
   "dependencies": {
     "@pack/client": "^0.0.7",
-    "@pack/hydrogen": "^0.0.7",
-    "@pack/react": "^0.0.14",
+    "@pack/hydrogen": "^0.1.0",
+    "@pack/react": "^0.1.0",
     "@remix-run/react": "^2.4.1",
     "@shopify/cli": "^3.53.0",
     "@shopify/cli-hydrogen": "^6.1.0",


### PR DESCRIPTION
Update the storefront to utilize the latest packages that provide Customizer overlay support.

Requires snagging the `customizerMeta` from the preview session and passing to the `<PreviewProvider />` where it is used by `@pack/react` to inject properly.